### PR TITLE
Update web_socket.dart

### DIFF
--- a/lib/src/web_socket.dart
+++ b/lib/src/web_socket.dart
@@ -162,4 +162,28 @@ class WebSocket {
       _connectionController.close();
     });
   }
+
+      Future<void> ready() async {
+    if (_channel == null) {
+      await _waitForChannel();
+    }
+    await _channel!.ready;
+  }
+
+  Future<void> _waitForChannel() {
+    if (_channel != null) return Future.value();
+
+    final completer = Completer<void>();
+
+    void checkChannel() {
+      if (_channel != null) {
+        completer.complete();
+      } else {
+        Future.delayed(Duration(milliseconds: 10), checkChannel);
+      }
+    }
+
+    checkChannel();
+    return completer.future;
+  }
 }


### PR DESCRIPTION
Added a Method that waits for connection and completes the future using 'ready' function  from web_socket_channel package. This way, if  one doesn't want to listen to the state, can still wait for the connection.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY/IN DEVELOPMENT/HOLD**

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
